### PR TITLE
Fixes hooks not working in some cases

### DIFF
--- a/src/main/java/com/joanzapata/mapper/HookWrapper.java
+++ b/src/main/java/com/joanzapata/mapper/HookWrapper.java
@@ -35,11 +35,10 @@ class HookWrapper<S, D> {
                 Class<?>[] parameterTypes = method.getParameterTypes();
                 Class<?> sourceClass = parameterTypes[0];
                 Class<?> destinationClass = parameterTypes[1];
-                if (sourceClass.isAssignableFrom(source.getClass()) &&
+                if (sourceClass != Object.class && destinationClass != Object.class && sourceClass.isAssignableFrom(source.getClass()) &&
                         destinationClass.isAssignableFrom(destination.getClass())) {
                     applySafe((S) source, (D) destination);
                 }
-                return;
             }
         }
     }


### PR DESCRIPTION
The compiler seems to generate two `extraMapping` methods for Hook<S, D> implementations. Their signatures looks like the following:
- `extraMapping(Object, Object)`
- `extraMapping(S, D)`

The code was stopping at the first one thus leading to possible ClassCastExceptions and making the mapping invalid.

This pull request aims at solving this problem by going through all generated `extraMapping` methods and ignoring the `extraMapping(Object, Object)` version.

No test yet. Can't find a simple way to test it for now.
